### PR TITLE
Remove routes and their controllers

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -12,5 +12,3 @@ app.use(express.urlencoded({ extended: false }));
 app.use(express.json());
 
 app.use(cors());
-
-app.use(graphqlRouter);

--- a/server/controllers/graphql.controller.ts
+++ b/server/controllers/graphql.controller.ts
@@ -1,9 +1,0 @@
-import { NextFunction, Request, Response } from "express";
-
-export const graphqlController = (
-  req: Request,
-  res: Response,
-  next: NextFunction
-) => {
-  next();
-};

--- a/server/controllers/index.ts
+++ b/server/controllers/index.ts
@@ -1,1 +1,0 @@
-export * from "./graphql.controller";

--- a/server/routes/graphql.route.ts
+++ b/server/routes/graphql.route.ts
@@ -1,6 +1,0 @@
-import express from "express";
-import { graphqlController } from "../controllers";
-
-export const router = express.Router();
-
-router.get("/graphql", graphqlController);

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -1,3 +1,0 @@
-import { router as graphqlRouter } from "./graphql.route";
-
-export { graphqlRouter };


### PR DESCRIPTION
Since I'm using Graphql for all of the endpoints ( at least for now), there is no need for routes or controllers.
